### PR TITLE
get rid of external dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,3 @@ Froggy is a prototype for the Component Graph System programming model. It aims 
 
 [workspace]
 members = ["demos/cubes"]
-
-[dependencies]
-bit_field = "0.7.0"

--- a/src/bitfield.rs
+++ b/src/bitfield.rs
@@ -1,8 +1,9 @@
-extern crate bit_field;
-use self::bit_field::BitField;
-
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct PointerData(u64);
+
+const INDEX_MASK: u64 = 0x0000_00FF_FFFF_FFFF;
+const EPOCH_MASK: u64 = 0x00FF_FF00_0000_0000;
+const SID_MASK: u64 = 0xFF00_0000_0000_0000;
 
 impl PointerData {
     #[inline]
@@ -16,31 +17,50 @@ impl PointerData {
 
     #[inline]
     pub fn get_index(&self) -> usize {
-        self.0.get_bits(0..40) as usize
+        (self.0 & INDEX_MASK) as usize
     }
 
     #[inline]
     pub fn get_epoch(&self) -> ::Epoch {
-        self.0.get_bits(40..56) as ::Epoch
+        ((self.0 & EPOCH_MASK)>>40) as ::Epoch
     }
 
     #[inline]
     pub fn get_storage_id(&self) -> ::StorageId {
-        self.0.get_bits(56..64) as ::StorageId
+        ((self.0 & SID_MASK)>>56) as ::StorageId
     }
 
     #[inline]
     pub fn set_index(&mut self, value: usize) {
-        self.0.set_bits(0..40, value as u64);
+        debug_assert!(value as u64 <= INDEX_MASK);
+        self.0 = (self.0 & (!INDEX_MASK)) + value as u64;
     }
 
     #[inline]
     pub fn set_epoch(&mut self, value: ::Epoch) {
-        self.0.set_bits(40..56, value as u64);
+        self.0 = (self.0 & (!EPOCH_MASK)) + ((value as u64) << 40);
     }
 
     #[inline]
     pub fn set_storage_id(&mut self, value: ::StorageId) {
-        self.0.set_bits(56..64, value as u64);
+        self.0 = (self.0 & (!SID_MASK)) + ((value as u64) << 56);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn rw_pointer_data() {
+        let mut pd = PointerData::new(1, 2, 3);
+        assert_eq!(pd.get_index(), 1);
+        assert_eq!(pd.get_epoch(), 2);
+        assert_eq!(pd.get_storage_id(), 3);
+        pd.set_index(2);
+        assert_eq!(pd.get_index(), 2);
+        pd.set_epoch(4);
+        assert_eq!(pd.get_epoch(), 4);
+        pd.set_storage_id(6);
+        assert_eq!(pd.get_storage_id(), 6);
     }
 }


### PR DESCRIPTION
This PR gets rid of the `bit_field` dependency.

Benchmark on my local machine:

## Before:
```
test bench_build  ... bench:   1,278,206 ns/iter (+/- 237,475)
test bench_update ... bench:      11,448 ns/iter (+/- 1,920)
...
test bench_build  ... bench:     727,021 ns/iter (+/- 127,100)
test bench_update ... bench:       2,264 ns/iter (+/- 201)
```

## With `bit_field`:

```
test bench_build  ... bench:   1,404,364 ns/iter (+/- 223,314)
test bench_update ... bench:      13,494 ns/iter (+/- 4,488)
...
test bench_build  ... bench:     937,293 ns/iter (+/- 166,870)
test bench_update ... bench:       3,783 ns/iter (+/- 451)
```

## After

```
test bench_build  ... bench:   1,301,554 ns/iter (+/- 422,869)
test bench_update ... bench:       9,692 ns/iter (+/- 1,618)
...
test bench_build  ... bench:     721,164 ns/iter (+/- 109,739)
test bench_update ... bench:       2,177 ns/iter (+/- 458)
```